### PR TITLE
ommiting __fieldName in isRowEditable

### DIFF
--- a/src/callbackGetters.ts
+++ b/src/callbackGetters.ts
@@ -30,7 +30,7 @@ export const _isRowEditable = ({ schema, modelName, node, parentNode, fieldOrder
       { schema: SchemaBuilderType, modelName: string, node: NodeType, parentNode?: NodeType, fieldOrder?: [string], customProps?: any }) => {
   if (!fieldOrder) {
     // @ts-ignore
-    fieldOrder = Object.keys(node)
+    fieldOrder = Object.keys(R.omit(['__typename'], node))
   }
   for (const index in fieldOrder) {
     // @ts-ignore


### PR DESCRIPTION
`__typename` needs to be ommited here, as it's treated as a column name when it's passed to `schema.isFieldEditable`, causing a false editable flag on the row that shows the edit button when no user is logged in.

