### PR TITLE
Updated getter functions for hasIndex and hasDetail

### DIFF
--- a/src/miscGetters.ts
+++ b/src/miscGetters.ts
@@ -42,12 +42,26 @@ export const _getRequiredFields = (
 export const _getHasIndex = (
   schema: SchemaBuilderType,
   modelName: string
-): boolean => schema.getModel(modelName).hasIndex || true
+): boolean => {
+  const field = schema.getModel(modelName).hasIndex
+  if (typeof field !== 'undefined') {
+    return field || false
+  } else {
+    return true
+  }
+}
 
 export const _getHasDetail = (
   schema: SchemaBuilderType,
   modelName: string
-): boolean => schema.getModel(modelName).hasDetail || true
+): boolean => {
+  const field = schema.getModel(modelName).hasDetail
+  if (typeof field !== 'undefined') {
+    return field || false
+  } else {
+    return true
+  }
+}
 
 export const _getSingleton = (
   schema: SchemaBuilderType,


### PR DESCRIPTION
Old code always returns true. The expected behavior is for the value to be true if the field is not defined, otherwise the value of the field. May need additional changes for if hasIndex is defined but not a boolean.