### PR TITLE
Enabled github action cache

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+            path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            restore-keys: |
+              ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn
       - name: Build
@@ -22,6 +32,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+            path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            restore-keys: |
+              ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn
       - name: Lint
@@ -32,6 +52,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+            path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            restore-keys: |
+              ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn
       - name: Test


### PR DESCRIPTION
Enabling yarn cache based on yarn.lock, but still need to run yarn to take care of node_modules dependencies.
Will not do anything on the first run (multiple yarn commands), but newer PR and pushes will use the cache if yarn.lock matches something in cache.